### PR TITLE
Migrate gh-action-pypi-publish Action to a Release

### DIFF
--- a/workflow-templates/python-deploy-artifacts.yml
+++ b/workflow-templates/python-deploy-artifacts.yml
@@ -35,7 +35,7 @@ jobs:
           path: python/dist/
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/${{steps.package-version.outputs.VERSION_STRING}}
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: python/dist/

--- a/workflow-templates/python-deploy-artifacts.yml
+++ b/workflow-templates/python-deploy-artifacts.yml
@@ -35,7 +35,6 @@ jobs:
           path: python/dist/
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/${{steps.package-version.outputs.VERSION_STRING}}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: python/dist/

--- a/workflow-templates/python-deploy-artifacts.yml
+++ b/workflow-templates/python-deploy-artifacts.yml
@@ -36,5 +36,3 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages_dir: python/dist/


### PR DESCRIPTION
# Description

Migrating gh-action-pypi-publish action to use a release version.

# Linked Items:

Closes/Fixes/Resolves #6 

### Added

- _Describe any new features._

### Changed

- _Describe any changes in existing functionality._

### Deprecated

- _Describe any deprecated features._

### Removed

- _Describe any removed features._

### Fixed

- _Describe any bug fixes._

### Security

- _Describe any security-related changes._

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [ ] I bumped the version.
- [ ] I added the labels corresponding to my changes.
