### PR TITLE
Updating Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -7,6 +7,7 @@ labels: [
 projects: [
   "DevOps-MBSE/1"
 ]
+type: "Bug"
 body:
   - type: checkboxes
     id: pre-requistes

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -8,14 +8,8 @@ labels: [
 projects: [
   "DevOps-MBSE/1"
 ]
+type: "Feature"
 body:
-  - type: textarea
-    id: reference_issues
-    attributes:
-      label: "Reference Issues"
-      placeholder: "#<Issue IDs>"
-    validations:
-      required: false
   - type: textarea
     id: summary
     attributes:
@@ -23,6 +17,13 @@ body:
       placeholder: Describe in a few lines your feature request.
     validations:
       required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: "Definition of Done"
+      placeholder: Provide a list of criteria by which to judge the effort as done.
+    validations:
+      required: false
   - type: textarea
     id: basic_example
     attributes:
@@ -42,5 +43,12 @@ body:
     attributes:
       label: "Unresolved questions"
       placeholder: Identify any unresolved issues.
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: "Additional Resources"
+      placeholder: Provide any additional useful information, guides, or resources for supporting this effort.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/SIMPLE-TASK.yml
+++ b/.github/ISSUE_TEMPLATE/SIMPLE-TASK.yml
@@ -7,14 +7,8 @@ labels: [
 projects: [
   "DevOps-MBSE/1"
 ]
+type: "Task"
 body:
-  - type: input
-    id: parent_feature
-    attributes:
-      label: "Parent Feature"
-      placeholder: "#<Issue ID>"
-    validations:
-      required: true
   - type: textarea
     id: summary
     attributes:
@@ -37,5 +31,12 @@ body:
     attributes:
       label: "Unresolved questions"
       placeholder: Identify any unresolved issues.
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: "Additional Resources"
+      placeholder: Provide any additional useful information, guides, or resources for supporting this effort.
     validations:
       required: false


### PR DESCRIPTION
# Description

Updating issue templates to work with new GitHub Issue implementation.

# Linked Items:

N/A

### Added

- Optional entries for additional resources or reference material.
- Type category now provided for additional issue granularity and display in projects.


### Deprecated

- Providing a parentage for issues is now provided by new GitHub Issue implementation, so does not need managed by the templates any longer. 

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [ ] I bumped the version.
- [x] I added the labels corresponding to my changes.
